### PR TITLE
Change match url to https://*.twitter.com/*

### DIFF
--- a/vqfft.user.js
+++ b/vqfft.user.js
@@ -8,7 +8,7 @@
 // @description:zh      强制 Twitter 播放最高画质的视频
 // @description:zh-CN   强制 Twitter 播放最高画质的视频
 // @author              flyhaozi
-// @match               https://twitter.com/*
+// @match               https://*.twitter.com/*
 // @grant               none
 // ==/UserScript==
 

--- a/vqfft.user.js
+++ b/vqfft.user.js
@@ -8,7 +8,8 @@
 // @description:zh      强制 Twitter 播放最高画质的视频
 // @description:zh-CN   强制 Twitter 播放最高画质的视频
 // @author              flyhaozi
-// @match               https://*.twitter.com/*
+// @match               https://twitter.com/*
+// @match               https://mobile.twitter.com/*
 // @grant               none
 // ==/UserScript==
 


### PR DESCRIPTION
This way it'll also pick up mobile.twitter.com. Useful for mobile browsers that support userscripts (Firefox, Kiwi, Yandex...). No other change is needed as twitter.com and mobile.twitter.com are the exact same website nowadays after classic layout was removed (no idea why they even still keep the distinction and redirect mobile to the latter still...)